### PR TITLE
Fix APIs used in the Distributed Model Parameter Search samples

### DIFF
--- a/model_parameter_search/distributing.md
+++ b/model_parameter_search/distributing.md
@@ -3,31 +3,35 @@
 For all model parameter search methods and `cross_val_score`, you have the choice of running the jobs locally or remotely.
 
 ### Local
-By default, jobs are scheduled to run locally in an asynchronous fashion. This is called a [LocalAsync environment](https://dato.com/products/create/docs/generated/graphlab.deploy.environment.LocalAsync.html). 
+By default, jobs are scheduled to run locally in an asynchronous fashion. This is called a LocalAsync environment.
 
 ### Remote
-You may also run jobs on an EC2 cluster or a Hadoop cluster. This is especially useful when you want to perform a larger scale paremeter search.
+You may also run jobs on an EC2 cluster or a Hadoop cluster. This is especially useful when you want to perform a larger scale parameter search.
 
-For EC2, you first create an EC2 environment and pass it into the `environment` argument: 
+For EC2, you first create an EC2 environment and pass it into the `environment` argument:
 ```
-ec2 = graphlab.deploy.environment.EC2('ec2_env_name', 's3://bucket/path')
-j = gl.model_parameter_search.create((train, valid), 
-                                     my_model, my_params, 
-                                     environment=ec2)
-```
+ec2config = graphlab.deploy.Ec2Config()
+ec2 = graphlab.deploy.ec2_cluster.create(name='mps',
+                                         s3_path='s3://bucket/path',
+                                         ec2_config=ec2config,
+                                         num_hosts=4)
 
-For more details on creating this environment, checkout the [API docs](https://dato.com/products/create/docs/generated/graphlab.deploy.environment.Hadoop.html#graphlab.deploy.environment.Hadoop) or the [Deployment](http://dato.com/learn/userguide/deployment/pipeline-introduction.html) chapter of the userguide.
+j = graphlab.model_parameter_search.create((train, valid),
+                                           my_model, my_params,
+                                           environment=ec2)
+```
 
 For launching jobs on a Hadoop cluster, you instead create a Hadoop environment and pass this object into the `environment` argument:
 
 ```
-hd = graphlab.deploy.environment.Hadoop(‘hd’, config_dir=<local-conf-path>)
-j = gl.model_parameter_search.create((train, valid), 
-                                     my_model, my_params, 
-                                     environment=hd)
+hd = gl.deploy.hadoop_cluster.create(name='hadoop-cluster',
+                                     dato_dist_path=<path to installation>)
+
+j = graphlab.model_parameter_search.create((train, valid),
+                                           my_model, my_params,
+                                           environment=hd)
 ```
-For more details on creating this environment, checkout the [API docs](https://dato.com/products/create/docs/generated/graphlab.deploy.environment.EC2.html#graphlab.deploy.environment.EC2) or the [Deployment](http://dato.com/learn/userguide/deployment/pipeline-introduction.html) chapter of the userguide.
 
-When getting started, it's useful to keep `perform_trial_run=True` to make sure you are creating your models properly.
+For more details on creating EC2- and Hadoop-based environment, checkout the [API docs](https://dato.com/products/create/docs/graphlab.deploy.html) or the [Deployment](http://dato.com/learn/userguide/deployment/pipeline-introduction.html) chapter of the userguide.
 
-
+When getting started, it is useful to keep `perform_trial_run=True` to make sure you are creating your models properly.


### PR DESCRIPTION
The code snippets on the Distributed Model Parameter Search page are out of sync with the
latest release. Also fixed a few outdated links.

Assigning @chrisdubois to the PR as he seems to be the previous author.