### PR TITLE
Improve usability of deployment chapter

### DIFF
--- a/deployment/introduction.md
+++ b/deployment/introduction.md
@@ -1,25 +1,21 @@
 # Deployment
 
-In this chapter we demonstrate how GraphLab Create makes it easy to take
-predictive applications to production, by enabling batch processing with
-asynchronous and distributed job execution through Dato Distrbuted, and real-time querying and
-consumption of Predictive Objects (ie. Models) with Dato Predictive
-Services. Note that jobs can be arbitrary python code.
+In this chapter we demonstrate how GraphLab Create makes it easy to take predictive applications to production, by enabling batch processing with asynchronous and distributed job execution through Dato Distributed, and real-time querying and consumption of predictive objects (models or custom functions) with Dato Predictive Services. Note that jobs can be arbitrary python code.
 
 Here is a short summary of what you can do with each of these features:
 
-** Batch processing with Dato Distributed**
+#### Batch processing with Dato Distributed
 
 - Run distributed jobs in your Hadoop cluster.
 - Run distributed jobs in Amazon's EC2 cloud computing environment.
 - Scale out your scenario using map-reduce concepts.
-- Execute toolkits transparently in a cluster.
+- Transparently scale out the execution of GraphLab Create toolkits through Distributed Machine Learning (DML).
 
 [<img alt="Jobs Dashboard in GraphLab Canvas" src="images/jobs-dashboard.png" style="max-height: 500px; max-width: 60%; margin-left: 15%;" />](images/jobs-dashboard.png)
 
-** GraphLab Predictive Services **
+#### GraphLab Predictive Services
 
-- Deploy trained GraphLab models into a elastic web service with a single line of code.
+- Deploy trained GraphLab Create models into a elastic web service with a single line of code.
 - Incorporate business logic with the ability to deploy arbitrary python code.
 - Scale up/down the number of nodes in the web service based on needs.
 - Easily update or switch the deployed models without any downtime.

--- a/deployment/pipeline-hadoop-setup.md
+++ b/deployment/pipeline-hadoop-setup.md
@@ -1,6 +1,6 @@
 # Setting up Dato Distributed on Hadoop
 
-If you decide to use Dato Distributed in your own Hadoop cluster, you will first need to download and install it there.
+Dato Distributed runs either in the Cloud (using AWS) or on-premises (Hadoop/YARN). If you use it in the Cloud the setup of Dato Distributed happens behind the scenes, all you need is to provide your credentials for AWS. If you decide to use Dato Distributed in your own Hadoop cluster, you will first need to download and install it there.
 
 #### Prerequisites
 

--- a/deployment/pipeline-introduction.md
+++ b/deployment/pipeline-introduction.md
@@ -8,16 +8,18 @@ In order to work with a Dato Distributed deployment (either on an on-premises cl
 
 The following chapters provide more details on the following aspects of remote and asynchronous job execution:
 
-**Asynchronous Jobs** describes how you can execute jobs asynchronously, but still within you local machine. Note that this functionality does not depend on Dato Distributed.
+[Asynchronous Jobs](pipeline-launch.md) describes how you can execute jobs asynchronously, but still within you local machine. Note that this functionality does not depend on Dato Distributed.
 
-**EC2 & Hadoop** provides a walk-through of submitting jobs to EC2 as well as Hadoop.
+[Installing on Hadoop](pipeline-hadoop-setup.md) explains how to install Dato Distributed on your local Hadoop environment.
 
-An **end-to-end example** demonstrates how to implement a recommender and run it as a remote job.
+[Clusters](pipeline-ec2-hadoop.md) provides a walk-through of submitting jobs to EC2 as well as Hadoop.
 
-**Distributed Job Execution** shows how to scale out a job across multiple remote computation nodes to reduce its run time.
+An [end-to-end example](pipeline-example.md) demonstrates how to implement a recommender and run it as a remote job.
 
-**Monitoring Jobs** outlines how to gain insight into the status and health of previously submitted jobs.
+[Distributed Machine Learning](pipeline-dml.md) introduces the concept of executing Dato toolkits in a distributed environment transparently.
 
-**Session Management** contains information about how to maintain local references to jobs and environments.
+[Monitoring Jobs](pipeline-monitoring-jobs.md) outlines how to gain insight into the status and health of previously submitted jobs.
 
-The chapter about **Dependencies** explains how external packages required by your use case can be included in the job deployment and execution.
+[Session Management](pipeline-keeping-track-of-jobs-tasks-and-environments.md) contains information about how to maintain local references to jobs and environments.
+
+The chapter about [Dependencies](pipeline-dependencies.md) explains how external packages required by your use case can be included in the job deployment and execution.

--- a/deployment/pred-working-with-objects.md
+++ b/deployment/pred-working-with-objects.md
@@ -160,7 +160,7 @@ curl -X POST -d '{"api_key": "b0a1c056-30b9-4468-9b8d-c07289017228",
      http://first-8410747484.us-west-2.elb.amazonaws.com/query/get-similar-products
 ```
 
-To help the consumer of your custom query, the doc string for your query is automatically extracted from your custom query function. You can get the doc string back via the `get_doc_string()` API:
+To help the consumer of your custom query, the doc string for your query is automatically extracted from your custom query function. You can get the doc string back via the [`describe`](https://dato.com/products/create/docs/generated/graphlab.deploy.PredictiveService.describe.html) API:
 
 ```python
 print deployment.describe('get-similar-products')


### PR DESCRIPTION
- Improve the deployment introduction page and fix a few typos there.
- update the Dato Distributed intro page to the latest structure and
  improve usability by inserting links to the sub-chapters.
- Improve the introductory paragraph of the Hadoop setup chapter.
- Fix a link bug in the PS chapter.