### PR TITLE
Update the autotagger chapter to use the current parameter names.

### DIFF
--- a/data_matching/autotagger.md
+++ b/data_matching/autotagger.md
@@ -81,17 +81,16 @@ posts.print_rows(5, max_row_width=100)
 |     None    | Similar to Weka, you may a... |    None    |      0       |
 |     None    | Scortchi and Peter Flom ha... |    None    |      3       |
 +-------------+-------------------------------+------------+--------------+
-+---------------------------+---------------+------------+-------+------+-------+----------+
-|        CreationDate       | FavoriteCount | PostTypeId | Score | Tags | Title | all_text |
-+---------------------------+---------------+------------+-------+------+-------+----------+
-| 2014-06-01 00:03:48+00:00 |      None     |     2      |   3   | None |  None |   None   |
-| 2014-06-01 00:09:09+00:00 |      None     |     2      |   1   | None |  None |   None   |
-| 2014-06-01 01:26:06+00:00 |      None     |     2      |   1   | None |  None |   None   |
-| 2014-06-01 01:29:40+00:00 |      None     |     2      |   0   | None |  None |   None   |
-| 2014-06-01 01:32:17+00:00 |      None     |     2      |   5   | None |  None |   None   |
-|            ...            |      ...      |    ...     |  ...  | ...  |  ...  |   ...    |
-+---------------------------+---------------+------------+-------+------+-------+----------+
-[11077 rows x 11 columns]
++---------------------------+---------------+------------+-------+------+-------+
+|        CreationDate       | FavoriteCount | PostTypeId | Score | Tags | Title |
++---------------------------+---------------+------------+-------+------+-------+
+| 2014-06-01 00:03:48+00:00 |      None     |     2      |   3   | None |  None |
+| 2014-06-01 00:09:09+00:00 |      None     |     2      |   1   | None |  None |
+| 2014-06-01 01:26:06+00:00 |      None     |     2      |   1   | None |  None |
+| 2014-06-01 01:29:40+00:00 |      None     |     2      |   0   | None |  None |
+| 2014-06-01 01:32:17+00:00 |      None     |     2      |   5   | None |  None |
++---------------------------+---------------+------------+-------+------+-------+
+[11077 rows x 10 columns]
 ```
 
 There is currently only one autotagger model, accessible through the
@@ -103,76 +102,73 @@ shingles, and computes the distance between tags and queries with weighted
 Jaccard distance.
 
 ```python
-posts['all_text'] = posts['Title'] + ' ' + posts['Body']
-m = gl.autotagger.create(topics)
+m = gl.autotagger.create(topics, verbose=False)
 m.summary()
 ```
 ```no-highlight
 Class                               : NearestNeighborAutoTagger
 
+Settings
+--------
 Number of examples                  : 2732
 Number of feature columns           : 3
-Total training time (seconds)       : 0.0549
+Total training time (seconds)       : 0.0514
 ```
 
-There are two key parameters when querying the model: `k`, which indicates the
-maximum number of tags to return for each query, and `radius`, which indicates
-the maximum distance from a query document to the tag. The most typical usage is
-to get preliminary results by setting `k` to 5 and leaving `radius` unspecified.
-Use the `radius` parameter to tune the final results for optimal precision and
-recall.
+There are two key parameters when querying the model: `k`, which indicates the maximum number of tags to return for each query, and `similarity_threshold`, which indicates the minimum similarity from a query document to the tag. A typical pattern is to get preliminary results by setting `k` to 5 and leaving `similarity_threshold` unspecified, then run `tag` again using the `similarity_threshold` parameter for finely-tuned results.
+
+The query documents must be a single column of the query SFrame, so we first concatenate the CrossValidate post titles and bodies.
 
 ```python
-tags = m.tag(posts, query_name='all_text', k=5, radius=0.9, verbose=True)
+posts['all_text'] = posts['Title'] + ' ' + posts['Body']
+tags = m.tag(posts, query_name='all_text', k=5, similarity_threshold=0.1, 
+             verbose=True)
 tags.print_rows(10, max_row_width=100, max_column_width=50)
 ```
 ```no-highlight
+PROGRESS: Starting pairwise querying.
+PROGRESS: +--------------+---------+-------------+--------------+
+PROGRESS: | Query points | # Pairs | % Complete. | Elapsed Time |
+PROGRESS: +--------------+---------+-------------+--------------+
+PROGRESS: | 0            | 692     | 0.00228667  | 26.525ms     |
+PROGRESS: | 4844         | 1.3e+07 | 43.7346     | 1.02s        |
+PROGRESS: | 9692         | 2.6e+07 | 87.4989     | 2.03s        |
+PROGRESS: | Done         |         | 100         | 2.29s        |
+PROGRESS: +--------------+---------+-------------+--------------+
 +-------------+---------------------------------------------------+
 | all_text_id |                      all_text                     |
 +-------------+---------------------------------------------------+
 |      13     | neural network output layer for binary classif... |
 |      13     | neural network output layer for binary classif... |
 |      13     | neural network output layer for binary classif... |
+|      13     | neural network output layer for binary classif... |
+|      13     | neural network output layer for binary classif... |
 |      37     | Negative predictions for binomial predictions ... |
+|      55     | Estimating entropy of multidimensional variabl... |
 |      80     | Does the sequence satisfy WLLN? Could you help... |
 |      80     | Does the sequence satisfy WLLN? Could you help... |
 |      80     | Does the sequence satisfy WLLN? Could you help... |
-|      80     | Does the sequence satisfy WLLN? Could you help... |
-|      80     | Does the sequence satisfy WLLN? Could you help... |
-|     102     | Guessing starting values for PARAMETERS statem... |
 +-------------+---------------------------------------------------+
 +---------------------------------------------------+----------------+
 |                       topic                       |     score      |
 +---------------------------------------------------+----------------+
-|               Binary classification               | 0.152671755725 |
-|              One-class classification             | 0.107913669065 |
-|             Artificial neural network             | 0.106382978723 |
-|             Negative predictive value             | 0.102564102564 |
-|                Law of large numbers               | 0.210526315789 |
+|               Binary classification               | 0.15503875969  |
+|             Artificial neural network             | 0.107913669065 |
+|              One-class classification             | 0.101449275362 |
+|                   Neural network                  | 0.100775193798 |
+|             Multiclass classification             | 0.10071942446  |
+|             Negative predictive value             | 0.104712041885 |
+|                Dimension reduction                | 0.101123595506 |
+|                Law of large numbers               | 0.197916666667 |
 | Independent and identically distributed random... | 0.186046511628 |
 |          Convergence of random variables          | 0.177570093458 |
-|             Law of truly large numbers            | 0.152380952381 |
-|        Dependent and independent variables        | 0.140350877193 |
-|                Nonlinear regression               | 0.114864864865 |
-|                        ...                        |      ...       |
 +---------------------------------------------------+----------------+
-[1310 rows x 4 columns]
+[1356 rows x 4 columns]
 ```
 
-Note that the *score* column in the tags output is a *similarity* score, while
-the `radius` parameter is in terms of weighted Jaccard distance. So setting the
-radius to 0.9, for example, requires that all output query-tag matches have a
-similarity score of at least 0.1.  In these particular results we see that that
-a post that appears to be about "binary classification" indeed receives this
-topic as its top match, while the post about the weak law of large numbers
-(WLLN) is appropriately tagged with "Law of large numbers."
+Note that the *score* column in the tags output is a *similarity* score, unlike the `radius` parameter in many other tools in GraphLab Create. The similarity in the autotagger is simply 1 minus the weighted jaccard distance, so setting the `similarity_threshold` to 0.1, for example, requires that all output query-tag matches have a weighted jaccard distance of no more than 0.9.  In these particular results we see that that a post that appears to be about "binary classification" indeed receives this topic as its top match, while the post about the weak law of large numbers (WLLN) is appropriately tagged with "Law of large numbers."
 
-Post-processing of the autotagger toolkit generally involves straightforward
-SFrame operations. For example, suppose we want to compare our model-generated
-tags to the human-generated ones attached to original question posts. To do this
-we first *filter* the unstructured dataset of posts by post type, then *unstack*
-the tags output to get a list of tags for each query in a single row, and
-finally *join* the original posts to the tags.
+Post-processing of the autotagger toolkit generally involves straightforward SFrame operations. For example, suppose we want to compare our model-generated tags to the human-generated ones attached to original question posts. To do this we first *filter* the unstructured dataset of posts by post type, then *unstack* the tags output to get a list of tags for each query in a single row, and finally *join* the original posts to the tags.
 
 ```python
 tags.rename({'all_text_id': 'id'})


### PR DESCRIPTION
The Autotagger chapter had not been updated since the `radius` parameter was changed to `similarity_threshold`.