### PR TITLE
A set of fixes and updates in various deployment chapters

### DIFF
--- a/deployment/pipeline-ec2-hadoop.md
+++ b/deployment/pipeline-ec2-hadoop.md
@@ -26,7 +26,7 @@ ec2 = gl.deploy.ec2_cluster.create(name='dato-kaggle',
 
 At this point you can use the object `ec2` for remote and distributed job execution.
 
-It is important to note that the [`create`](https://dato.com/products/create/docs/generated/graphlab.deploy.ec2_cluster.create.html) call will already start the hosts in EC2, so costs will be incurred at that point. They will be shutdown after an idle period, which is 10 minutes by default or set as parameter (in seconds) in the create method. Setting the timeout to a negative value will cause the cluster to run indefinitely or until explicitly stopped. For example, if you wanted to extend the timeout to one hour you would create the cluster like so:
+It is important to note that the [`create`](https://dato.com/products/create/docs/generated/graphlab.deploy.ec2_cluster.create.html) call will already start the hosts in EC2, so costs will be incurred at that point. They will be shutdown after an idle period, which is 30 minutes by default or set as parameter (in seconds) in the create method. Setting the timeout to a negative value will cause the cluster to run indefinitely or until explicitly stopped. For example, if you wanted to extend the timeout to one hour you would create the cluster like so:
 
 ```python
 ec2 = gl.deploy.ec2_cluster.create(name='dato-kaggle',

--- a/deployment/pred-getting-started.md
+++ b/deployment/pred-getting-started.md
@@ -4,7 +4,7 @@ In this section we will walk through an end-to-end example of deploying and usin
 
 #### Configuration
 
-In order to launch a Predictive Service in EC2 we first need to configure the EC2 Config object, which contains required configuration parameters.
+In order to launch a Predictive Service in EC2 we first need to configure the [`graphlab.deploy.Ec2Config`](https://dato.com/products/create/docs/generated/graphlab.deploy.Ec2Config.html)  object, which contains required configuration parameters.
 
 ```no-highlight
 import graphlab
@@ -15,7 +15,7 @@ ec2 = graphlab.deploy.Ec2Config(region='us-west-2',
                                 aws_secret_access_key='YOUR_SECRET_KEY')
 ```
 
-The configuration object is client-side only; it's purpose is merely to encapsulate a set of parameters and pass them to the `create()` command.
+The configuration object is client-side only; its purpose is merely to encapsulate a set of parameters and pass them to the `create` command.
 
 #### Launch the Predictive Service
 

--- a/deployment/pred-intro.md
+++ b/deployment/pred-intro.md
@@ -1,9 +1,6 @@
 # Introduction to Predictive Services
-GraphLab Predictive Services enable straightforward deployment of machine
-learning models as reliable and scalable web services for easy integration into
-predictive applications using a low-latency REST API. With one command, launch a
-cluster, deploy a model, update a model (with no downtime), or capture
-interaction data to improve the next version of the model.
+
+GraphLab Predictive Services enable straightforward deployment of machine learning models as reliable and scalable web services for easy integration into predictive applications using a low-latency REST API. With one command, launch a cluster, deploy a model, update a model (with no downtime), or capture interaction data to improve the next version of the model.
 
 The following chapters walk through an end-to-end Predictive Services example, then elaborate on specific aspects:
 

--- a/deployment/pred-launching.md
+++ b/deployment/pred-launching.md
@@ -2,7 +2,7 @@
 
 #### Configuration
 
-In order to launch a Predictive Service you first need to configure it by instantiating a [graphlab.deploy.predictive_service.Ec2Config](https://dato.com/products/create/docs/generated/graphlab.deploy.Ec2Config.html) object:
+In order to launch a Predictive Service you first need to configure it by instantiating a [`graphlab.deploy.Ec2Config`](https://dato.com/products/create/docs/generated/graphlab.deploy.Ec2Config.html) object:
 
 ```python
 ec2 = graphlab.deploy.Ec2Config(region='us-west-2',
@@ -10,6 +10,8 @@ ec2 = graphlab.deploy.Ec2Config(region='us-west-2',
                                 aws_access_key_id='YOUR_ACCESS_KEY',
                                 aws_secret_access_key='YOUR_SECRET_KEY')
 ```
+
+Click on the link above to go to the API documentation, which has more details on supported EC2 instance types.
 
 As an alternative to explicitly specifying the AWS credentials as parameters to the config you can also set them in your shell:
 
@@ -28,7 +30,7 @@ If this security group does not exist, a new one will be created.
 
 #### Deployment
 
-With a valid configuration, a Predictive Service is launched using the [graphlab.deploy.predictive_service.create](https://dato.com/products/create/docs/generated/graphlab.deploy.predictive_service.create.html#graphlab.deploy.predictive_service.create) command:
+With a valid configuration, a Predictive Service is launched using the [`graphlab.deploy.predictive_service.create`](https://dato.com/products/create/docs/generated/graphlab.deploy.predictive_service.create.html#graphlab.deploy.predictive_service.create) command:
 
 ```python
 deployment = graphlab.deploy.predictive_service.create(
@@ -39,7 +41,7 @@ The 3rd parameter&mdash;the state path&mdash;is a S3 path that is used to manage
 
 When the `create` command is executed, the EC2 instances will be launched immediately, followed by a load balancer which adds the instances into the cluster as they pass health checks.
 
-There are additional, optional parameters to [`create()`](https://dato.com/products/create/docs/generated/graphlab.deploy.predictive_service.create.html#graphlab.deploy.predictive_service.create) including:
+There are additional, optional parameters to [`create`](https://dato.com/products/create/docs/generated/graphlab.deploy.predictive_service.create.html#graphlab.deploy.predictive_service.create) including:
 
 1. number of hosts for EC2
 2. description of this service

--- a/deployment/pred-working-with-objects.md
+++ b/deployment/pred-working-with-objects.md
@@ -1,26 +1,26 @@
 # Working with Objects
-Predictive Services host your models in a scalable REST-ful webservice. All GraphLab Create Models are Predictive Objects. In addition to deploying GraphLab Create Models, we support Custom Predictive Objects for composing multiple Models and GraphLab Create data structures. With Custom Predictive Objects, you can deploy arbitrary business logic on top of your Models simply by defining a Python function. In this chapter we will demonstrate both the usage of a model as well as a Custom Predictive Object in a Predictive Service.
+Dato Predictive Services host your models in a scalable REST-ful webservice. In addition to all GraphLab Create models, we support _custom predictive objects_ for composing multiple Models and GraphLab Create data structures. With custom predictive objects, you can deploy arbitrary business logic on top of your models simply by defining a Python function. In this chapter we will demonstrate both the usage of a model as well as a Custom Predictive Object in a predictive service.
 
-Let's train a GraphLab Create Model. For the rest of this chapter we will utilize this model when interacting with Predictive Services.
+Let's train a GraphLab Create model. For the rest of this chapter we will utilize this model when interacting with Predictive Services.
 
-```no-highlight
+```python
 data_url = 'https://s3.amazonaws.com/dato-datasets/movie_ratings/sample.small'
 data = graphlab.SFrame.read_csv(data_url,delimiter='\t',column_type_hints={'rating':int})
 model = graphlab.popularity_recommender.create(data, 'user', 'movie', 'rating')
 ```
 
-#### Add a Predictive Object to the deployment
+#### Add a Predictive Object to the Deployment
 
-The Predictive Service Deployment's [`add()`](https://dato.com/products/create/docs/generated/graphlab.deploy._predictive_service._predictive_service.PredictiveService.add.html#graphlab.deploy._predictive_service._predictive_service.PredictiveService.add) method stages a Predictive Object for deployment to the cluster.
+The [`PredictiveService.add`](https://dato.com/products/create/docs/generated/graphlab.deploy.PredictiveService.add.html) method stages a Predictive Object for deployment to the cluster.
 
-```no-highlight
-deployment.add('recs', model)
+```python
+ps.add('recs', model)
 ```
 
-Now if you print the deployment there will be pending change for the newly added object.
+Now if you print the PredictiveService object there will be pending change for the newly added object.
 
-```no-highlight
-print deployment
+```python
+print ps
 ```
 
 ```
@@ -37,29 +37,29 @@ Pending changes:
 	Adding: recs description:
 ```
 
-To finish publishing this Predictive Object -- a recommender model -- call the
-[`apply_changes()`](https://dato.com/products/create/docs/generated/graphlab.deploy._predictive_service._predictive_service.PredictiveService.apply_changes.html#graphlab.deploy._predictive_service._predictive_service.PredictiveService.apply_changes) method. When you call this API, the pending Predictive Objects will be uploaded to S3, and the cluster will be notified to download them from S3.
+To finish publishing this Predictive Object&mdash;a recommender model&mdash;call the
+[`apply_changes`](https://dato.com/products/create/docs/generated/graphlab.deploy.PredictiveService.apply_changes.html) method. When you call this API, the pending predictive objects will be uploaded to S3, and the cluster will be notified to download them from S3.
 
-```no-highlight
-deployment.apply_changes()
+```python
+ps.apply_changes()
 ```
 
-Of course you can deploy more than one Predictive Object. The [`PredictiveService.add`](https://dato.com/products/create/docs/generated/graphlab.deploy.PredictiveService.add.html) API can be called repeatedly to deploy multiple predictive objects (models or custom predictive functions):
+Of course you can deploy more than one Predictive Object. The `add` API can be called repeatedly to deploy multiple predictive objects (models or custom predictive functions):
 
-```no-highlight
-deployment.add(name='sim_model', obj=item_similarity_model)
-deployment.add(name='fact_model', obj=factorization_model)
+```python
+ps.add(name='sim_model', obj=item_similarity_model)
+ps.add(name='fact_model', obj=factorization_model)
 ```
 
 Each object can be queried explicitly and directly, using its name:
 
-```no-highlight
-recs_sim = deployment.query('sim_model',
-                            method='recommend',
-                            data={'users':['Jacob Smith']})
-recs_fact = deployment.query('fact_model',
-                             method='recommend',
-                             data={'users':['Jacob Smith']})
+```python
+recs_sim = ps.query('sim_model',
+                    method='recommend',
+                    data={'users': ['Jacob Smith']})
+recs_fact = ps.query('fact_model',
+                     method='recommend',
+                     data={'users': ['Jacob Smith']})
 ```
 
 Each deployment of a Predictive Object creates an endpoint for the object, which can be queried directly through HTTP (assuming an example DNS name):
@@ -75,18 +75,18 @@ http://first-8410747484.us-west-2.elb.amazonaws.com/query/fact_model
 
 #### Update an existing Predictive Object
 
-The Predictive Service Deployment's
-[update](https://dato.com/products/create/docs/generated/graphlab.deploy._predictive_service._predictive_service.PredictiveService.update.html#graphlab.deploy._predictive_service._predictive_service.PredictiveService.update) method stages an existing Predictive Object for this deployment to be updated, which results in the object's version being incremented. Once ```apply_changes()``` is called, the updated object will be proactively warmed in the distributed cache, and existing cached entries for this model will be expired and purged in 15 minutes. Using this method to update an existing object ensures rolling updates with zero downtime. By pre-emptively warming the cache you can be confident that latencies will not spike with popular requests during an update.
+The predictive service's
+[`update`](https://dato.com/products/create/docs/generated/graphlab.deploy.PredictiveService.update.html) method stages an existing Predictive Object for this deployment to be updated, which results in the object's version being incremented. Once `apply_changes` is called, the updated object will be proactively warmed in the distributed cache, and existing cached entries for this model will be expired and purged in 15 minutes. Using this method to update an existing object ensures rolling updates with zero downtime. By pre-emptively warming the cache you can be confident that latencies will not spike with popular requests during an update.
 
-```no-highlight
+```python
 new_model = graphlab.recommender.create(...)
-deployment.update('recs', new_model)
-deployment.apply_changes()
+ps.update('recs', new_model)
+ps.apply_changes()
 ```
 
 #### Define a Custom Predictive Object
 
-Often times, you want to be able to include some additional logic with your predictive model&mdash;you may want to combine results from multiple models and return a prediction; you my want to apply some transformations to the output of a model before returning; you may want to join your input data with other dataset(s) before passing it to the model. With GraphLab Create, it's easy to deploy your custom logic in a Predictive Service.
+Often times, you want to be able to include some additional logic with your predictive model&mdash;you may want to combine results from multiple models and return a prediction; you my want to apply some transformations to the output of a model before returning; you may want to join your input data with other dataset(s) before passing it to the model. With GraphLab Create, it's easy to deploy your custom logic in a predictive service.
 
 Let's look at an example. Suppose you want to take as input a product ID and recommend similar products to a user. You have already trained a nearest neighbor model that you want to use, but the input from your website is simply a product ID, so you need to join the product ID with other information in your database before feeding the product information to the model. Let's say we have an SFrame that captures production information:
 
@@ -126,29 +126,28 @@ def recommend_similar_products(product_id):
     return products.filter_by(neighbors['reference_label'], 'id')
 ```
 
-Now add the custom Predictive Object to your Predictive Service with the
-[add](https://dato.com/products/create/docs/generated/graphlab.deploy._predictive_service._predictive_service.PredictiveService.add.html#graphlab.deploy._predictive_service._predictive_service.PredictiveService.add) or [update](https://dato.com/products/create/docs/generated/graphlab.deploy._predictive_service._predictive_service.PredictiveService.update.html#graphlab.deploy._predictive_service._predictive_service.PredictiveService.update) methods.
+Now add the custom Predictive Object to your predictive service with the `add` or `update` methods.
 
-Given an existing Predictive Service deployment, and a handle to it (by way of a variable named "deployment"), the snippet below demonstrates how you would add your own custom logic to the Predictive Service deployment:
+Given an existing predictive service deployment, and a handle to it (by way of a variable named `ps`), the snippet below demonstrates how you would add your own custom logic to the predictive service deployment:
 
 ```python
-deployment.add('get-similar-products', recommend_similar_products,
-               description='Get two similar products given a product id')
+ps.add('get-similar-products', recommend_similar_products,
+       description='Get two similar products given a product id')
 ```
 
-In fact, what we've done is simply to define a query function and add it to our Predictive Service deployment. Behind the scenes, that function is used to instantiate a Predictive Object.
+In fact, what we've done is simply to define a query function and add it to our predictive service deployment. Behind the scenes, that function is used to instantiate a Predictive Object.
 
-Before you deploy your new custom query to production, it's a good idea to do a local test of the query using [test_query](https://dato.com/products/create/docs/generated/graphlab.deploy._predictive_service._predictive_service.PredictiveService.test_query.html#graphlab.deploy._predictive_service._predictive_service.PredictiveService.test_query). This method runs your query locally, but simulates the actual end-to-end flow of serializing inputs, running the query and returning the serialized result.
+Before you deploy your new custom query to production, it's a good idea to do a local test of the query using [`test_query`](https://dato.com/products/create/docs/generated/graphlab.deploy.PredictiveService.test_query.html). This method runs your query locally, but simulates the actual end-to-end flow of serializing inputs, running the query and returning the serialized result.
 
 ```python
-deployment.test_query('get-similar-products', product_id=1)
+ps.test_query('get-similar-products', product_id=1)
 ```
 
 After you are done, deploy to production and run the query:
 
 ```python
-deployment.apply_changes()
-deployment.query('get-similar-products', product_id=1)
+ps.apply_changes()
+ps.query('get-similar-products', product_id=1)
 ```
 
 Like for a regular model you can use the HTTP endpoint directly to query the custom predictive object. In the POST body you reference the API key as well as the method's parameter name and value:
@@ -163,7 +162,7 @@ curl -X POST -d '{"api_key": "b0a1c056-30b9-4468-9b8d-c07289017228",
 To help the consumer of your custom query, the doc string for your query is automatically extracted from your custom query function. You can get the doc string back via the [`describe`](https://dato.com/products/create/docs/generated/graphlab.deploy.PredictiveService.describe.html) API:
 
 ```python
-print deployment.describe('get-similar-products')
+print ps.describe('get-similar-products')
 ```
 
 ```
@@ -176,11 +175,11 @@ None
 
 To list all currently deployed predictive objects, you can use the following API:
 
-```no-highlight
-print deployment.deployed_predictive_objects
+```python
+print ps.deployed_predictive_objects
 ```
 
-```no-highlight
+```python
 {'recommender_one': 2, 'recommender_two': 1}
 ```
 
@@ -190,7 +189,7 @@ Parameters that are passed to or returned by a Custom Predictive Object need to 
 
 ##### Logging in a Custom Predictive Object
 
-You may want to do some custom logging in your Custom Predictive Object. We inject a `log` method into your function just for this purpose. Any information logged using this function would automatically be written to a custom log file. The log file is rotated periodically and shipped to the same S3 log location you specified when creating your Predictive Service, exactly like the
+You may want to do some custom logging in your Custom Predictive Object. We inject a `log` method into your function just for this purpose. Any information logged using this function would automatically be written to a custom log file. The log file is rotated periodically and shipped to the same S3 log location you specified when creating your predictive service, exactly like the
 query and feedback logs (see [Logging and Feedback](pred-logging-feedback.md)).
 
 Here is an example of logging from within your custom method:
@@ -202,8 +201,8 @@ def my_query(param1, param2):
     # other logic continues
 ```
 
-If you want to inspect the custom log immediately, you can call the Predictive Service's
-[`flush_logs`](https://dato.com/products/create/docs/generated/graphlab.deploy._predictive_service._predictive_service.PredictiveService.flush_logs.html) method to force logs to be shipped to your S3 log path.
+If you want to inspect the custom log immediately, you can call the predictive service's
+[`flush_logs`](https://dato.com/products/create/docs/generated/graphlab.deploy.PredictiveService.flush_logs.html) method to force logs to be shipped to your S3 log path.
 
 To consume the log, see the [Logging and Feedback](pred-logging-feedback.md) section in this user guide.
 
@@ -213,7 +212,7 @@ If your custom logic depends on other Python packages, you should use the `@grap
 
 For example, if your query depends on a package called 'names', then you would do the following:
 
-```no-highlight
+```python
 @graphlab.deploy.required_packages(['names=0.3.0'])
 def generate_names(num_names):
     import names
@@ -224,27 +223,27 @@ Notice the format for the required_packages parameter is consistent with the for
 
 ##### Dependent Python Files
 
-If your custom query is defined in another Python file, or if it depends on other Python files you’ve created, you may instruct GraphLab Create to package those files for you by using the @graphlab.deploy.required_files decorator.
+If your custom query is defined in another Python file, or if it depends on other Python files you have created, you may instruct GraphLab Create to package those files for you by using the ``@graphlab.deploy.required_files` decorator.
 
 For example, if you have a set of Python scripts in a folder called ‘product_recommender’, and your custom query depends on all Python files in that folder:
 
-```no-highlight
+```python
 @graphlab.deploy.required_files('product_recommender', '*.py')
     def recommend_similar_products(product_id):
         from product_recommend import query_db
         ...
 ```
 
-The first parameter to `required_files` can be a file name, a folder name or a list containing both file or folder names. GraphLab Create automatically extracts the required files and ships them to the Predictive Service cluster. The second parameter is a file name "glob" pattern that is used to select only the files that are needed. It is implemented using the [fnmatch](https://docs.python.org/2/library/fnmatch.html) Python package.
+The first parameter to `required_files` can be a file name, a folder name or a list containing both file or folder names. GraphLab Create automatically extracts the required files and ships them to the predictive service cluster. The second parameter is a file name "glob" pattern that is used to select only the files that are needed. It is implemented using the [fnmatch](https://docs.python.org/2/library/fnmatch.html) Python package.
 
 #### Removing a Predictive Object
 
-To remove a Predictive Object from your deployment, simply call the [remove](https://dato.com/products/create/docs/generated/graphlab.deploy._predictive_service._predictive_service.PredictiveService.remove.html#graphlab.deploy._predictive_service._predictive_service.PredictiveService.remove) method, which takes the name of the object to be removed as a parameter. Like the ```add``` method, this has the effect of staging a change, but it will not take affect until ```apply_changes``` is called.
+To remove a Predictive Object from your deployment, simply call the [remove](https://dato.com/products/create/docs/generated/graphlab.deploy.PredictiveService.remove.html) method, which takes the name of the object to be removed as a parameter. Like the `add` method, this has the effect of staging a change, but it will not take affect until `apply_changes` is called.
 
 For example, the following command will remove a previously added Predictive Object with the name `get-similar-products`:
 
-```no-highlight
-deployment.remove('get-similar-products')
+```python
+ps.remove('get-similar-products')
 ```
 
 Note that this call will fail if the model is referred to by a policy or an alias (see [chapter about experimentation](pred-experimentation.html)). You can find out whether such a dependency exist by calling [`PredictiveService.get_endpoint_dependencies`](https://dato.com/products/create/docs/generated/graphlab.deploy.PredictiveService.get_endpoint_dependencies.html).


### PR DESCRIPTION
- Correct the cluster timeout for EC2 to 30min.
- Add another link to the API doc for Ec2Config where the allowed EC2
  instances are specified.
- Fix typos and link bugs in the Predictive Objects chapter.