### PR TITLE
Fixed the (relative) path on the links

### DIFF
--- a/feature-engineering/numeric_features.md
+++ b/feature-engineering/numeric_features.md
@@ -2,7 +2,7 @@
 
 These transformations are useful when you have numeric data.
 
-* [Quadratic Features](feature-engineering/quadratic_features.md)
-* [Feature Binning](feature-engineering/feature_binner.md)
-* [Numeric Imputer](feature-engineering/numeric_imputer.md)
+* [Quadratic Features](quadratic_features.md)
+* [Feature Binning](feature_binner.md)
+* [Numeric Imputer](numeric_imputer.md)
 


### PR DESCRIPTION
The links as written don't work. Fixed the duplicated "feature engineering/" (unnecessary given location of this file/how file paths are globbed), so they work now.