### PR TITLE
Update sframe-intro.md

### DIFF
--- a/sframe/sframe-intro.md
+++ b/sframe/sframe-intro.md
@@ -34,7 +34,7 @@ Reference](https://dato.com/products/create/docs/generated/graphlab.SFrame.read_
 Once done we can inspect the first few rows of the tables we've imported.
 
 ```python
-songs
+songs.dtype
 ```
 
 ```


### PR DESCRIPTION
Running
```python
songs
```
only returns the head of the SFrame, as can be seen in this screenshot from my local machine:

![image](https://cloud.githubusercontent.com/assets/13375615/14627516/0aa5cc28-05aa-11e6-80fd-5005e42ee2b2.png)

To get the output actually [shown in the user guide](https://dato.com/learn/userguide/sframe/sframe-intro.html),  
One must instead run 
```python
songs.dtype
```
Also shown here:
![image](https://cloud.githubusercontent.com/assets/13375615/14627557/63ea58a8-05aa-11e6-9216-56b1201769e1.png)


